### PR TITLE
Handle picker font size adjustment, fix layout issues. 

### DIFF
--- a/NumericPicker-Example/Base.lproj/Main.storyboard
+++ b/NumericPicker-Example/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,25 +23,25 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="xIZ-94-obd" userLabel="IB Picker Stack">
-                                <rect key="frame" x="30" y="28" width="329" height="263"/>
+                                <rect key="frame" x="16" y="28" width="343" height="263"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Added in Interface Builder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PIV-6N-h47">
-                                        <rect key="frame" x="31" y="0.0" width="267" height="26.5"/>
+                                        <rect key="frame" x="38" y="0.0" width="267" height="26.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PCQ-NW-D3N" userLabel="IB Picker Label Stack">
-                                        <rect key="frame" x="0.0" y="26.5" width="329" height="20.5"/>
+                                        <rect key="frame" x="38" y="26.5" width="267" height="20.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Picker Value" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2xg-L6-RrW" userLabel="IB Picker Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="164.5" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="133.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1ka-BM-xgU" userLabel="IB Picker Value">
-                                                <rect key="frame" x="164.5" y="0.0" width="164.5" height="20.5"/>
+                                                <rect key="frame" x="133.5" y="0.0" width="133.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -49,10 +49,7 @@
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ju9-jE-Y1x" userLabel="IB Numeric Picker" customClass="NumericPicker" customModule="NumericPicker">
-                                        <rect key="frame" x="4.5" y="47" width="320" height="216"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="320" id="HTa-fx-xdY"/>
-                                        </constraints>
+                                        <rect key="frame" x="0.0" y="47" width="343" height="216"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="minIntegerDigits">
                                                 <integer key="value" value="6"/>
@@ -70,7 +67,10 @@
                                     </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="PCQ-NW-D3N" firstAttribute="width" secondItem="xIZ-94-obd" secondAttribute="width" id="WHE-kZ-cLL"/>
+                                    <constraint firstItem="ju9-jE-Y1x" firstAttribute="leading" secondItem="xIZ-94-obd" secondAttribute="leading" id="2uy-6m-Gex"/>
+                                    <constraint firstItem="PIV-6N-h47" firstAttribute="centerX" secondItem="xIZ-94-obd" secondAttribute="centerX" id="Hgz-DI-tQQ"/>
+                                    <constraint firstItem="PCQ-NW-D3N" firstAttribute="width" secondItem="PIV-6N-h47" secondAttribute="width" id="RG4-4e-F4W"/>
+                                    <constraint firstAttribute="trailing" secondItem="ju9-jE-Y1x" secondAttribute="trailing" id="pC7-SU-dA5"/>
                                 </constraints>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hOJ-b9-7ru" userLabel="Separator">
@@ -81,16 +81,16 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="wEt-Tb-mCw" userLabel="Code Picker Stack">
-                                <rect key="frame" x="30" y="309" width="329" height="47"/>
+                                <rect key="frame" x="16" y="309" width="343" height="47"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Added in Code (German format)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3rm-AR-A2w">
-                                        <rect key="frame" x="0.0" y="0.0" width="329" height="26.5"/>
+                                        <rect key="frame" x="7" y="0.0" width="329" height="26.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="fMo-yv-pOi" userLabel="Code Picker Label Stack">
-                                        <rect key="frame" x="0.0" y="26.5" width="329" height="20.5"/>
+                                        <rect key="frame" x="7" y="26.5" width="329" height="20.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Picker Value" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BvF-4l-Kmo" userLabel="Code Picker Label">
                                                 <rect key="frame" x="0.0" y="0.0" width="164.5" height="20.5"/>
@@ -108,20 +108,23 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="fMo-yv-pOi" firstAttribute="width" secondItem="wEt-Tb-mCw" secondAttribute="width" id="GU9-s8-04y"/>
+                                    <constraint firstItem="3rm-AR-A2w" firstAttribute="centerX" secondItem="wEt-Tb-mCw" secondAttribute="centerX" id="FOS-5D-5a6"/>
+                                    <constraint firstItem="fMo-yv-pOi" firstAttribute="centerX" secondItem="wEt-Tb-mCw" secondAttribute="centerX" id="V7D-pA-9n8"/>
+                                    <constraint firstItem="fMo-yv-pOi" firstAttribute="width" secondItem="3rm-AR-A2w" secondAttribute="width" id="sGR-BS-qkj"/>
                                 </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="hOJ-b9-7ru" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="1oU-3y-3jm"/>
+                            <constraint firstItem="wEt-Tb-mCw" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="4wJ-Ez-lr2"/>
+                            <constraint firstItem="xIZ-94-obd" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="5Ce-zj-W6M"/>
                             <constraint firstItem="wEt-Tb-mCw" firstAttribute="top" secondItem="hOJ-b9-7ru" secondAttribute="bottom" constant="8" symbolic="YES" id="5GA-tw-cVJ"/>
                             <constraint firstItem="hOJ-b9-7ru" firstAttribute="top" secondItem="xIZ-94-obd" secondAttribute="bottom" constant="8" symbolic="YES" id="Au3-rt-j4O"/>
                             <constraint firstItem="hOJ-b9-7ru" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" id="LPo-7e-t5t"/>
                             <constraint firstItem="xIZ-94-obd" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="8" symbolic="YES" id="dko-T4-lYJ"/>
-                            <constraint firstItem="wEt-Tb-mCw" firstAttribute="leading" secondItem="xIZ-94-obd" secondAttribute="leading" id="eQn-fE-zMc"/>
-                            <constraint firstItem="wEt-Tb-mCw" firstAttribute="trailing" secondItem="xIZ-94-obd" secondAttribute="trailing" id="h8y-PR-Ptz"/>
                             <constraint firstAttribute="trailingMargin" secondItem="xIZ-94-obd" secondAttribute="trailing" id="s2g-1c-mj3"/>
+                            <constraint firstItem="wEt-Tb-mCw" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="wQb-J3-Xxk"/>
                         </constraints>
                     </view>
                     <connections>

--- a/NumericPicker-Example/ViewController.swift
+++ b/NumericPicker-Example/ViewController.swift
@@ -43,7 +43,8 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         ibNumericPicker.value = 12345.6
-
+        ibNumericPicker.font = UIFont.systemFont(ofSize: 54)
+        
         // Configure a NumericPicker in code
         codeNumericPicker.minIntegerDigits = 6
         codeNumericPicker.fractionDigits = 3

--- a/NumericPicker.podspec
+++ b/NumericPicker.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NumericPicker'
-  s.version          = '0.5.0'
+  s.version          = '0.6.0'
   s.summary          = 'iOS picker for easily selecting numbers by digit. (Swift 4)'
 
   s.description      = <<-DESC

--- a/Sources/NumericPicker.swift
+++ b/Sources/NumericPicker.swift
@@ -39,11 +39,10 @@ import UIKit
     // MARK: - Properties
 
     /// The font for the components of the picker. (defaults to `Body`)
-    public var font = UIFont.preferredFont(forTextStyle: .body) {
+    @IBInspectable public var font = UIFont.preferredFont(forTextStyle: .title1) {
         didSet {
             picker.reloadAllComponents()
             generateAccessibilityLabels()
-            resize()
         }
     }
 
@@ -62,7 +61,6 @@ import UIKit
             numberFormatter.locale = locale
             updateAppearance(animated: false)
             generateAccessibilityLabels()
-            resize()
         }
     }
 
@@ -73,7 +71,6 @@ import UIKit
         didSet {
             updateAppearance(animated: false)
             generateAccessibilityLabels()
-            resize()
         }
     }
 
@@ -82,7 +79,6 @@ import UIKit
         didSet {
             updateAppearance(animated: false)
             generateAccessibilityLabels()
-            resize()
         }
     }
 
@@ -110,7 +106,6 @@ import UIKit
 
             guard justInstantiated else { return }
             justInstantiated = false
-            resize()
         }
     }
 
@@ -170,21 +165,14 @@ import UIKit
         picker.dataSource = self
         picker.isAccessibilityElement = false
         addSubview(picker)
+        picker.translatesAutoresizingMaskIntoConstraints = false
+        addConstraint(NSLayoutConstraint(item: picker, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1, constant: 0))
+        addConstraint(NSLayoutConstraint(item: picker, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1, constant: 0))
+        addConstraint(NSLayoutConstraint(item: picker, attribute: .leading, relatedBy: .equal, toItem: self, attribute: .leading, multiplier: 1, constant: 0))
+        addConstraint(NSLayoutConstraint(item: picker, attribute: .trailing, relatedBy: .equal, toItem: self, attribute: .trailing, multiplier: 1, constant: 0))
     }
 
     // MARK: - Picker Maintenance
-
-    /**
-     Resizes the `NumericPicker` to contain the all components. Called when a property affecting the picker's
-     appearance changes.
-     */
-    func resize() {
-        var pickerSize = picker.bounds.size
-        pickerSize.width = widthOfPickerView()
-        picker.bounds.size = pickerSize
-        frame.size = pickerSize
-        picker.frame = bounds
-    }
 
     /**
      Recalculates `displayString` and `componentsString` and refreshes the picker view. Called whenever a property
@@ -471,5 +459,11 @@ extension NumericPicker: UIPickerViewDelegate {
         let pickerLabel = self.pickerView(pickerView, viewForRow: 0, forComponent: component, reusing: nil)
         let width = pickerLabel.bounds.width + 8
         return width
+    }
+    
+    public func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        let pickerLabel = self.pickerView(pickerView, viewForRow: 0, forComponent: component, reusing: nil)
+        let height = pickerLabel.bounds.height + 8
+        return height
     }
 }


### PR DESCRIPTION
- Use AutoLayout instead of frame manipulation to control picker layout.
- Implement pickerView:rowHeightForComponent UIPickerView delegate method to provide row height. Required in order to adjust picker row height for bigger/smaller font sizes.
- Adjustments in NumericPicker-Example target accordingly. 